### PR TITLE
Fix writeConfig

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ def getUserOption(key = None, default = None):
         return default
 
 def writeConfig():
-    aqt.mw.addonManager.writeConfig(__name__,userOption)
+    mw.addonManager.writeConfig(__name__,userOption)
 
 def update(_):
     global userOption, fromName


### PR DESCRIPTION
`aqt.mw` is not found because you import `mw` using `from aqt import mw`, which doesn't make `aqt` available in the current file's namespace.