### PR TITLE
Solve #65 scrollbar issue

### DIFF
--- a/defaultcss.css
+++ b/defaultcss.css
@@ -1,3 +1,6 @@
+/* Prevent horizontal scrollbar overflow */
+body { overflow-x: hidden; }
+
 /* Tooltip container */
         a:hover{
          cursor: pointer;


### PR DESCRIPTION
Prevents the overflow of the horizontal scrollbar when the columns fit in the screen already; this solves #65 (and the duplicate #84).

From this:
![image](https://user-images.githubusercontent.com/61620873/96335175-efc85100-1076-11eb-845b-a7e99cec6101.png)

To this (no overflow):
![image](https://user-images.githubusercontent.com/61620873/96335183-07073e80-1077-11eb-9ff4-55c512ae0523.png)

Solution courtesy of @tiffanyhclau [here](https://github.com/Arthur-Milchior/anki-enhance-main-window/issues/84#issuecomment-636293717), simply put into PR form so that it is automatically done for all users.